### PR TITLE
init cpp properties and add a db file.

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -24,6 +24,23 @@ echo "$(date): Running on compute node ${compute_node}:$port"
 # VSCode complains that system git is too old.
 module load project/ondemand git app_code_server/<%= context.version %>
 
+CPP_FILE="<%= working_dir.to_s %>/.vscode/c_cpp_properties.json"
+
+if [[ -f "$CPP_FILE" ]]; then
+    CPP_DIR="${TMPDIR:=/tmp/$USER}/cpp-vscode"
+    mkdir -p "$CPP_DIR"
+    chmod 700 "$CPP_DIR"
+
+    # if the file is empty, let's initialize it
+    [ -s "$CPP_FILE" ] || echo '{"configurations": [{ "name": "Linux", "browse": { "databaseFilename": null }}], "version": 4}' > "$CPP_FILE"
+
+    jq --arg dbfile "$CPP_DIR/cpp-vscode.db" \
+      '.configurations[0].browse.databaseFilename = $dbfile' \
+      "$CPP_FILE" > "$CPP_FILE".new
+
+    mv "$CPP_FILE".new "$CPP_FILE"
+  fi
+
 #
 # Start Code Server.
 #


### PR DESCRIPTION
init cpp properties and add a db file to local storage so that cpp include lookups can index quickly. Also set's the directory to be 700 for security reasons.