### PR TITLE
Add code-server 4.5.1

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -9,6 +9,7 @@ attributes:
     widget: "select"
     label: "Codeserver Version"
     options:
+      - ["4.5", "4.5.1"]
       - ["3.9", "3.9.3"]
       - ["3.4", "3.4.1"]
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -51,7 +51,7 @@ code-server \
     --auth="password" \
     --bind-addr="0.0.0.0:${port}" \
     --disable-telemetry \
-    --extra-extensions-dir="$CODE_SERVER_DATAROOT/extensions" \
+    <%= context.version[0] == "3" ? "--extra-extensions-dir=\"$CODE_SERVER_DATAROOT/extensions\" \\" : "\\" %>
     --user-data-dir="$CODE_SERVER_DATAROOT" \
     --log debug \
     "<%= working_dir.to_s %>"


### PR DESCRIPTION
I have added 4.5.1 to `form.yml` and made changes in `script.sh.erb` due to the option `--extra-extensions-dir` is removed in version 4.

code-server can start normally but I cannot log in (with the message  "401 Unauthorized" on login page).  Here is my `output.log`

```
Script starting...
Thu Jul 28 14:49:52 EDT 2022: Waiting for Code Server to open port 7659...
Thu Jul 28 14:49:53 EDT 2022: Running on compute node :7659
Thu Jul 28 14:49:53 EDT 2022: Started code-server

[2022-07-28T18:49:55.706Z] info  code-server 4.5.1 97d170331b51ee75c8e4bbdab23c755e3eeaaa8c
[2022-07-28T18:49:55.707Z] info  Using user-data-dir ~/.local/share/code-server
[2022-07-28T18:49:55.725Z] info  Using config file ~/.config/code-server/config.yaml
[2022-07-28T18:49:55.725Z] info  HTTP server listening on http://0.0.0.0:7659/
[2022-07-28T18:49:55.725Z] info    - Authentication is enabled
[2022-07-28T18:49:55.725Z] info      - Using password from $PASSWORD
[2022-07-28T18:49:55.725Z] info    - Not serving HTTPS
Thu Jul 28 14:49:56 EDT 2022: Discovered code-server listening on port 7659!
Generating connection YAML file...
[14:50:14] Extension host agent started.
[2022-07-28T18:50:14.967Z] debug redirecting from /? to ./login?to=
[14:50:15] ComputeTargetPlatform: linux-x64
```