### PR TITLE
use pitzer instead of pitzer-login for apptainer updates

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,17 +1,30 @@
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
 ---
-cluster: "pitzer-login"
+cluster: "pitzer"
 form:
+  - account
   - bc_num_hours
   - working_dir
   - version
 attributes:
+  account:
+    label: "Project"
+    widget: select
+    options:
+      <%- groups.each do |group| %>
+      - "<%= group %>"
+    <%- end %>
   version:
     widget: "select"
     label: "Codeserver Version"
     options:
       - ["3.9", "3.9.3"]
       - ["3.4", "3.4.1"]
-      - ["4.5", "4.5.1"]
+      # - ["4.5", "4.5.1"]
 
   working_dir:
     label: "Working Directory"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -3,3 +3,5 @@ batch_connect:
   template: "basic"
   conn_params:
     - code_server_version
+script:
+  accounting_id: <%= account %>


### PR DESCRIPTION
With the apptainer update there's some issue with code server forking new processes that I haven't quite figured out yet. 

We also ran into the show stopper https://github.com/OSC/ood_core/issues/784 besides.