### PR TITLE
Removes irrelevant note from info.md.erb

### DIFF
--- a/info.md.erb
+++ b/info.md.erb
@@ -1,2 +1,1 @@
-Code Server launches inside of a [Singularity](https://sylabs.io/singularity/) container. **Note:** type `bash` to break out of the Singularity shell when using the integrated terminal in Code Server. 
-
+Code Server launches inside of a [Singularity](https://sylabs.io/singularity/) container.


### PR DESCRIPTION
From a ServiceNow ticket:

> When one starts a Code Server session in OSC OnDemand, the “card” in the “My Interactive Sessions” window will include the following text (see also the screenshot at the bottom of this email):
Code Server launches inside of a Singularity<[https://sylabs.io/singularity/>](https://urldefense.com/v3/__https://sylabs.io/singularity/*3E__;JQ!!KGKeukY!yNYL1ixuMBloaeOJZpNbZrOShNzaqBjnemJte6IZnpnwqXpwMj4N9QpmZHfZbJax0t6itwJZ5gIcbFd5ojVO$) container. Note: type bash to break out of the Singularity shell when using the integrated terminal in Code Server.
However, one used to need to type “bash”, but this is no longer necessary: nowadays, the terminal opens in a regular shell right away. Could you please update (remove ) these instructions? I’m preparing to do some OSC-related teaching and ran into this, as it may confuse students.