### PR TITLE
Fix auth: Use Argon2 to hash password

### DIFF
--- a/view.html.erb
+++ b/view.html.erb
@@ -1,11 +1,17 @@
 <%
   require 'digest'
+  require 'argon2'
 
   # Generate form id, based on host and port
   form_id = Digest::SHA1.hexdigest("--" + host.to_s + "--" + port.to_s + "--")
 
-  # Generate SHA256 digest of Code Server Password
-  cookieValue = Digest::SHA256.hexdigest(password)
+  # Generate Argon2 digest of Code Server Password
+  hasher = Argon2::Password.new(
+    t_cost: 3,      # Time cost (iterations)
+    m_cost: 16,  # Memory cost (in KiB)
+    p_cost: 4  # Parallelism (threads)
+  )
+  cookieValue = hasher.create(password)
 %>
 
 <script type="text/javascript">
@@ -14,21 +20,12 @@
   date.setTime(date.getTime() + (7*24*60*60*1000))
   let expires = "expires=" + date.toUTCString()
   let cookiePath = "path=/rnode/" + "<%= host.to_s %>" + "/" + "<%= port.to_s %>/";
-  /**
-    We have to use "key" as the cookie name since upstream in cdr/code-server
-    the authentication cookie is hard coded "key"
-  */
-  let cookie = `key=<%= cookieValue %>;${expires};${cookiePath};secure`;
+  let cookie = `code-server-session=<%= cookieValue %>;${expires};${cookiePath};secure`;
   document.cookie = cookie;
 })();
 </script>
 
-<% if code_server_version == '4.8.3' %>
-<form id="<%= form_id %>" action="/rnode/<%= host %>/<%= port %>/login?to=" method="post" target="_blank">
-  <input type="hidden" name="password" value="<%= password %>">
-<% else %>
 <form id="<%= form_id %>" action="/rnode/<%= host %>/<%= port %>/" method="get" target="_blank">
-<% end %>
   <button class="btn btn-primary" type="submit">
     <i class="fa fa-cogs"></i> Connect to VS Code
   </button>


### PR DESCRIPTION
I haven't tested all codeserver versions, but this works with the newer 4.x series for me.

The caveat is that OOD does not come with argon2 installed. Procedure to install (needs compiler):

```
scl enable ondemand -- gem install argon2
cd /var/www/ood/apps/sys/dashboard/
scn enable ondemand -- bundle add argon2
```
